### PR TITLE
Update EndeavourOS ISO URL for new format

### DIFF
--- a/settings.sh
+++ b/settings.sh
@@ -1,4 +1,4 @@
-URL="https://github.com/endeavouros-team/ISO/releases/download/1-EndeavourOS-ISO-releases-archive/EndeavourOS_Atlantis-REPLACE_VERSION.iso.torrent"
+URL="https://github.com/endeavouros-team/ISO/releases/download/1-EndeavourOS-ISO-releases-archive/EndeavourOS_REPLACE_VERSION.iso.torrent"
 TYPE=torrent
 CONTENTS="\
 arch/x86_64/airootfs.sfs|airootfs.sfs


### PR DESCRIPTION
The version string includes the release name now:

```
core@flatcar ~ $ curl -sL https://endeavouros.com/latest-release/ | awk -F '(EndeavourOS_|.iso)' '/EndeavourOS_/ {print $2; exit}' | cut -d '-' -f 2
Apollo_22_1
```

The torrent download succeeds now with this change: https://github.com/sdt16/asset-mirror/runs/6048989788