### PR TITLE
feat: Mercury is the current endeavouros release name

### DIFF
--- a/settings.sh
+++ b/settings.sh
@@ -1,4 +1,4 @@
-URL="https://mirror.alpix.eu/endeavouros/iso/EndeavourOS_Endeavour_neo-REPLACE_VERSION.iso.torrent"
+URL="https://mirror.alpix.eu/endeavouros/iso/EndeavourOS_Mercury-REPLACE_VERSION.iso.torrent"
 TYPE=torrent
 CONTENTS="\
 arch/x86_64/airootfs.sfs|airootfs.sfs

--- a/version.sh
+++ b/version.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
-VERSION=$(curl -sL https://endeavouros.com/ | awk -F '(EndeavourOS_Endeavour_neo-|.iso)' '/EndeavourOS_Endeavour_neo-/ {print $2; exit}')
+VERSION=$(curl -sL https://endeavouros.com/ | awk -F '(EndeavourOS_Mercury-|.iso)' '/EndeavourOS_Mercury-/ {print $2; exit}')
 echo "${VERSION}"


### PR DESCRIPTION
There is only an outdated version of EndeavourOS in the menus. The last pipeline was failing, not sure what caused it, but neo is outdated anyways now.