### PR TITLE
Cachyos - fix initramfs and vmlinux file names

### DIFF
--- a/settings.sh
+++ b/settings.sh
@@ -2,5 +2,5 @@ URL="https://cdn77.cachyos.org/ISO/desktop/REPLACE_VERSION/cachyos-desktop-linux
 TYPE=file
 CONTENTS="\
 arch/x86_64/airootfs.sfs|airootfs.sfs
-arch/boot/x86_64/initramfs-linux-cachyos.img|initrd
-arch/boot/x86_64/vmlinuz-linux-cachyos|vmlinuz"
+arch/boot/x86_64/initramfs-linux-cachyos-lts.img|initrd
+arch/boot/x86_64/vmlinuz-linux-cachyos-lts|vmlinuz"


### PR DESCRIPTION
Cachyos' latest iso adds '-lts' to these files.  I have added the updated names to the settings.sh