### PR TITLE
Support multi-part airootfs (>2 parts)

### DIFF
--- a/archiso_pxe_http
+++ b/archiso_pxe_http
@@ -52,9 +52,12 @@ archiso_pxe_http_mount_handler() {
         fi
     fi
     _curl_get "${archiso_http_srv}/airootfs.${img_type}" "/${arch}"
-    if [ ! -z "$(/bin/curl -sI "${archiso_http_srv}/airootfs.${img_type}.part2" | grep "200 OK\|302 Found\|HTTP/2 200\|HTTP/2 302" || :)" ]; then
-        curl -L -f "${archiso_http_srv}/airootfs.${img_type}.part2" -o ->> "/run/archiso/httpspace/${archisobasedir}/${arch}/airootfs.${img_type}"
-    fi
+    _part=2
+    while [ ! -z "$(/bin/curl -sI "${archiso_http_srv}/airootfs.${img_type}.part${_part}" | grep "200 OK\|302 Found\|HTTP/2 200\|HTTP/2 302" || :)" ]; do
+        msg ":: Downloading '${archiso_http_srv}/airootfs.${img_type}.part${_part}'"
+        curl -L -f "${archiso_http_srv}/airootfs.${img_type}.part${_part}" -o ->> "/run/archiso/httpspace/${archisobasedir}/${arch}/airootfs.${img_type}"
+        _part=$((_part + 1))
+    done
 
     # shellcheck disable=SC2154
     # defined via initcpio's parse_cmdline()


### PR DESCRIPTION
## Summary
- The current `archiso_pxe_http` hook fetches `airootfs.${img_type}` and concatenates `.part2`, but stops there.
- The producer (`docker-iso-processor/root/build.sh:67-73`) splits files >2 GB into **up to 3 parts** (`xaa`/`xab`/`xac` → base/`.part2`/`.part3`).
- Omarchy's `airootfs.sfs` is ~5.86 GiB → 3 parts. Only ~3.91 GiB ends up reassembled in tmpfs, the squashfs is truncated, and the loop-mount fails:
  > `losetup: ... Warning: file does not end on a 512-byte sector boundary`
  > `mount: /run/archiso/airootfs: wrong fs type, bad option, bad superblock on /dev/loop0`

## Fix
Replace the hardcoded `.part2` `if` with a `while` loop over `.part${N}` while one exists at the HTTP source.

## Compatibility
- 1-part (no split): unchanged — loop never enters.
- 2-part: unchanged — loop runs once for `.part2`, exits on missing `.part3`.
- 3+ parts (Omarchy today, future large ISOs): now works.

## Test plan
- [ ] Cut a fresh Omarchy release with this hook bundled
- [ ] PXE-boot Omarchy on a VM with ≥10 GiB RAM
- [ ] Confirm all three parts (`airootfs.sfs`, `.part2`, `.part3`) are downloaded
- [ ] Confirm the assembled file mounts cleanly and the live env starts
- [ ] Smoke test CachyOS (2-part) on the same hook to confirm no regression
- [ ] Smoke test SystemRescue (1-part) to confirm no regression

## Follow-up
Same fix should be applied to the `cachyos` and `systemrescue-amd64` branches (identical hook blob `9006e1c`); not strictly required to fix Omarchy, but prevents future latency if those distros ever cross the 4 GB threshold.