### PR TITLE
Add proxmox-ve-arm64 workflow

### DIFF
--- a/.github/workflows/proxmox-ve-arm64.yml
+++ b/.github/workflows/proxmox-ve-arm64.yml
@@ -1,0 +1,85 @@
+name: proxmox-ve-arm64
+
+on:
+  push:
+    branches:
+      - proxmox-ve-arm64
+    paths-ignore:
+      - '.github/workflows/**'
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+env:
+  BRANCH: proxmox-ve-arm64
+  GITHUB_ENDPOINT: netbootxyz/asset-mirror
+  DISCORD_HOOK_URL: ${{ secrets.DISCORD_HOOK_URL }}
+  BUILD_TYPE: iso_extraction
+  DEBIAN_FRONTEND: noninteractive
+  CI_TOKEN: ${{ secrets.CI_TOKEN }}
+
+jobs:
+  version-checker:
+    name: Version Checker
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: proxmox-ve-arm64
+
+    - name: Get SHA of actual branch instead of master
+      run: |
+        export GITHUB_SHA=$(git rev-parse HEAD)
+        echo "GITHUB_SHA=$GITHUB_SHA" >> $GITHUB_ENV
+
+    - name: Retrieve latest version from upstream and set vars
+      run: |
+        export EXTERNAL_VERSION=$(sudo bash version.sh)
+        echo "EXTERNAL_VERSION=$EXTERNAL_VERSION" >> $GITHUB_ENV
+        export GITHUB_TAG=${EXTERNAL_VERSION}-$(echo ${{ env.GITHUB_SHA }} | cut -c1-8)
+        echo "GITHUB_TAG=$GITHUB_TAG" >> $GITHUB_ENV
+        wget https://raw.githubusercontent.com/netbootxyz/build-pipelines/master/build.sh && chmod +x build.sh
+
+    - name: Compare tag
+      id: compare
+      run: ./build.sh compare ${{ env.GITHUB_TAG }}
+      continue-on-error: true
+
+    - name: Build if newer tag is available
+      if: steps.compare.outcome == 'success' && steps.compare.conclusion == 'success'
+      run: |
+        ./build.sh build ${{ env.BUILD_TYPE }}
+        git tag ${{ env.GITHUB_TAG }}
+
+    - name: Generate Release Notes
+      run: |
+        echo "Release generated for Branch: **${{ env.BRANCH }}**" > ${{ github.workspace }}-CHANGELOG.txt
+
+    - name: Create release and upload assets
+      if: steps.compare.outcome == 'success' && steps.compare.conclusion == 'success'
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ env.GITHUB_TAG }}
+        name: ${{ env.GITHUB_TAG }}
+        draft: false
+        prerelease: false
+        files: buildout/*
+        token: ${{ secrets.GITHUB_TOKEN }}
+        body_path: ${{ github.workspace }}-CHANGELOG.txt
+
+    - name: Generate endpoints
+      if: steps.compare.outcome == 'success' && steps.compare.conclusion == 'success'
+      run: |
+        git config --global user.name netboot-ci
+        git config --global user.email netboot-ci@netboot.xyz
+        ./build.sh endpoints ${{ env.GITHUB_TAG }}
+
+    - name: Notify Discord on failure
+      if: failure()
+      run: |
+        ./build.sh discord failure
+
+    - name: Notify Discord on completion
+      if: steps.compare.outcome == 'success' && steps.compare.conclusion == 'success' && success()
+      run: |
+        ./build.sh discord success


### PR DESCRIPTION
Adds the scheduled mirror workflow for **Proxmox VE arm64**.

Proxmox [launched official arm64 support](https://www.proxmox.com/en/about/company-details/press-releases/proxmox-virtual-environment-launches-official-arm64-support) on 2026-08-04, published as `proxmox-ve_<version>-arm64.iso` next to the x86-64 ISO. Closes the gap in netbootxyz/netboot.xyz#1404, which was previously declined because only an unofficial port existed.

### What's here

- `.github/workflows/proxmox-ve-arm64.yml` — identical to `proxmox-ve.yml` apart from the branch name.

The asset config was pushed separately to the [`proxmox-ve-arm64`](https://github.com/netbootxyz/asset-mirror/tree/proxmox-ve-arm64) branch, matching the `gentoo-amd64` / `gentoo-arm64` convention:

- `settings.sh` — `iso_extraction` of `boot/linux26` → `vmlinuz` and `boot/initrd.img` → `initrd`. Verified the arm64 ISO uses the same internal layout as the x86-64 one, so the recipe carries over unchanged.
- `version.sh` — matches only `-arm64` ISOs in `SHA256SUMS` and sorts with `sort -V` rather than relying on file order. Currently resolves to `9.2-1`.
- `endpoints.template` — publishes endpoint `proxmox-ve-arm64` with `os: proxmox-ve` and `arch: "arm64"`.
- `post-processing.sh` — unchanged from `proxmox-ve`.

Both pushes to that branch were sequenced so no build was triggered; the first run will come from the schedule or a manual dispatch after this merges.

### Companion change

netboot.xyz's `proxmox.ipxe.j2` needs the arch-gating change so the new endpoint is offered on arm64 and the x86-64-only products are hidden there — see the netboot.xyz PR.

### Heads up

`proxmox-ve`'s `version.sh` uses `grep proxmox-ve | tail -n 1` on `SHA256SUMS`. It still resolves correctly today (`-arm64` sorts before the plain `.iso`), but it will pick up the arm64 version if upstream ever publishes an arm64-only point release. Worth the same `grep -v -- -arm64` / `sort -V` treatment, left out here to avoid triggering a rebuild on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)